### PR TITLE
Refactoring events

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Show all active event. It could be sent in group chat or in a direct chat with V
 Options:
 - _-a_ (or "_all_") shows all events either open or finished
 
+`/event` info _NAME_
+
+Show the event information and bets
+
+Option is required:
+- NAME - Uniq name for new event. Should be one word with chars and digits only
+
 `/event` my _NAME_
 
 Show your personal bet in the particular event

--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ Show all active event. It could be sent in group chat or in a direct chat with V
 Options:
 - _-a_ (or "_all_") shows all events either open or finished
 
+`/event` my _NAME_
+
+Show your personal bet in the particular event
+
+Option is required:
+- NAME - Uniq name for new event. Should be one word with chars and digits only
+
+`/event` my _NAME_ rm
+
+Remove your personal bet from the particular event
+
+Option is required:
+- NAME - Uniq name for new event. Should be one word with chars and digits only
 
 `/event` close _NAME_ _RESULT_
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,98 @@
 # lbx-telebot
-bot for our small and nasty community
+bot for our group community
 
 *Available commands:*
 
 `/help` or `/h`
+
 Show this help.
 
 `/ver` or `/v`
+
 Show the current version.
 
-`/profile` [name]
-Show the stored profile of the requester or another user.
-Options:
-name - target chat participant.
+`/profile` _NAME_ _PERIOD_
 
-`/top`
+Show the stored profile of the requester or another user.
+
+Options:
+- _NAME_ - target chat participant
+- _PERIOD_ - custom period of statistic (e.g. 7d, 72h), should be > 0
+
+`/top` _NUM_ _PERIOD_
+
 Show top users.
 
-`/bottom`
-Show reversed rating.
+Options:
+- _NUM_ - custom number of positions to show, should be > 0
+- _PERIOD_ - custom period of statistic (e.g. 7d, 72h), should be > 0
+
+`/bottom` _NUM_ _PERIOD_
+
+Show reversed rating
+
+Options:
+- _NUM_ - custom number of positions to show, should be > 0
+- _PERIOD_ - custom period of statistic (e.g. 7d, 72h), should be > 0
+
+`/topic` _text_
+
+Set new title in the group
 
 `/event`
-Show detailed information about events
+
+Command for event. Send command without params for detailed instructions.
 
 `/today`
+
 Returns what happened on this day
+
+---
+
+`/event` create _NAME_
+
+Create new event with _NAME_ option. It could be sent in group chat or in a direct chat with Valera.
+You should have admin rights.
+
+Option is required:
+- NAME - Uniq name for new event. Should be one word with chars and digits only
+
+`/event` list \[_-a_ | _all_]
+
+Show all active event. It could be sent in group chat or in a direct chat with Valera.
+
+Options:
+- _-a_ (or "_all_") shows all events either open or finished
+
+
+`/event` close _NAME_ _RESULT_
+
+Close event with NAME and RESULT options. It could be sent in group chat or in a direct chat with Valera.
+
+You should have admin rights.
+
+Options are required:
+- _NAME_ - Uniq name for existing event. Should be one word with chars and digits only
+- _RESULT_ - Result of the event. Should be number
+
+`/event` result _NAME_
+
+Show result for event with given name. It could be sent in group chat or in a direct chat with Valera.
+
+Option is required:
+- _NAME_ - Uniq name for existing event. Should be one word with chars and digits only
+
+`/event` bet _NAME_ _VALUE_
+
+Make your bet with value. It could be sent in group chat or in a direct chat with Valera.
+
+Options are required:
+- _NAME_ - Uniq name for existing event. Should be one word with chars and digits only
+- _VALUE_ - Your bet for this event. Should be number
+
+`/event` share _NAME_
+
+Share event in administered groups
+
+Option is required:
+- _NAME_ - Uniq name for existing event. Should be one word with chars and digits only`

--- a/internal/const.go
+++ b/internal/const.go
@@ -3,7 +3,7 @@ package internal
 import "time"
 
 const (
-	Version = "2.7.1"
+	Version = "2.8.0"
 
 	Timeout     = 10 * time.Second
 	RatingLimit = 5

--- a/internal/handler/event.go
+++ b/internal/handler/event.go
@@ -273,14 +273,14 @@ func (h Handler) eventMy(c tele.Context, e model.Event) error {
 
 	if len(e.Opts) > 1 {
 		name := e.Opts[1]
-		event, _ := h.Storage.GetEventByName(ctx, e.Opts[1])
+		event, _ := h.Storage.GetEventByName(ctx, name)
 		if event.Name == "" {
 			_ = c.Send(fmt.Sprintf(errMsg, name), internal.MarkdownOpt)
 			return errors.New("wrong event in /event my command")
 		}
 
+		//case /event my e.Opts[1]
 		if len(e.Opts) == 2 {
-			//case /event my e.Opts[1]
 			parts, err := h.Storage.GetEventParticipantByEventName(ctx, name)
 			if err != nil {
 				return err
@@ -309,13 +309,22 @@ func (h Handler) eventMy(c tele.Context, e model.Event) error {
 			return nil
 		}
 
+		//case /event my eventname rm
 		if len(e.Opts) == 3 && e.Opts[2] == "rm" {
-			//case /event my e.Opts[1] rm
-			//TODO do not delete bet from finished event
-			fmt.Println("remove my bet from event ", e.Opts[1])
+			if event.Status == "opened" {
+				if err := h.Storage.RemoveBet(ctx, event, c.Sender().ID); err != nil {
+					return err
+				}
+				if err := c.Send("You bet has been removed"); err != nil {
+					return err
+				}
+				return nil
+			}
 
+			if err := c.Send("You can't remove your bet from finished event"); err != nil {
+				return err
+			}
 		}
-
 	}
 
 	return nil

--- a/internal/handler/event.go
+++ b/internal/handler/event.go
@@ -213,7 +213,7 @@ func (h Handler) eventList(c tele.Context, e model.Event) error {
 	}
 
 	resp := message.GetEventList(events, showAll)
-	_, err = c.Bot().Send(c.Sender(), resp, internal.MarkdownOpt)
+	err = c.Send(resp, internal.MarkdownOpt)
 	return err
 }
 
@@ -242,6 +242,8 @@ func (h Handler) eventResult(c tele.Context, newEvent model.Event) error {
 func (h Handler) eventBet(c tele.Context, newEvent model.Event, userId int64) error {
 	ctx := context.Background()
 
+	fmt.Printf("Sender: %v\n", c.Sender())
+
 	if err := h.Storage.StoreBet(ctx, newEvent, userId); err != nil {
 		resp := message.GetErrorMessage("saving bet")
 		_, err := c.Bot().Send(c.Sender(), resp, internal.MarkdownOpt)
@@ -249,7 +251,7 @@ func (h Handler) eventBet(c tele.Context, newEvent model.Event, userId int64) er
 	}
 
 	resp := fmt.Sprintf("Your bet `%v` for event `%v` is accepted!", newEvent.Bet, newEvent.Name)
-	_, err := c.Bot().Send(c.Sender(), resp, internal.MarkdownOpt)
+	err := c.Send(resp, internal.MarkdownOpt)
 	return err
 }
 

--- a/internal/handler/event.go
+++ b/internal/handler/event.go
@@ -19,7 +19,7 @@ import (
 //	It could have variants of payload
 //	- create with name of event
 //	- close with name of event and result
-//	- show to get all events with statuses
+//	- list to get all events with statuses
 //	- bet with name of event and value of bet
 //	- result to get result of closed event
 //	- share to send event to administered group or channel

--- a/internal/handler/event.go
+++ b/internal/handler/event.go
@@ -264,6 +264,9 @@ func (h Handler) eventShare(c tele.Context, newEvent model.Event, administeredGr
 }
 
 // eventMy handle /event my command to work with own bets in the given event
+// This command can let see the requester own bet for the requested event and also remove it
+// The requester can see his bet from any events including finished, but can delete a bet
+// from opened event only.
 func (h Handler) eventMy(c tele.Context, e model.Event) error {
 	ctx := context.Background()
 	errMsg := "Incorrect event name _%s_. You can try use `/event list` command to see all ongoing events"
@@ -272,13 +275,12 @@ func (h Handler) eventMy(c tele.Context, e model.Event) error {
 		name := e.Opts[1]
 		event, _ := h.Storage.GetEventByName(ctx, e.Opts[1])
 		if event.Name == "" {
-			_ = c.Send(fmt.Sprintf(errMsg, e.Opts[1]), internal.MarkdownOpt)
+			_ = c.Send(fmt.Sprintf(errMsg, name), internal.MarkdownOpt)
 			return errors.New("wrong event in /event my command")
 		}
 
 		if len(e.Opts) == 2 {
 			//case /event my e.Opts[1]
-
 			parts, err := h.Storage.GetEventParticipantByEventName(ctx, name)
 			if err != nil {
 				return err
@@ -304,7 +306,7 @@ func (h Handler) eventMy(c tele.Context, e model.Event) error {
 			if err := c.Send(message.GetMyBets(name, bet)); err != nil {
 				return err
 			}
-
+			return nil
 		}
 
 		if len(e.Opts) == 3 && e.Opts[2] == "rm" {

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -189,6 +189,11 @@ func GetEventCreate(event model.Event) string {
 	return msg.String()
 }
 
+// GetMyBets formats get my bet message
+func GetMyBets(event string, bet int64) string {
+	return fmt.Sprintf("Your bet for the event `%s` is %d\n", event, bet)
+}
+
 // CreateRating returns message with information about given profiles
 func CreateRating(profiles []model.Profile, opt model.Option) string {
 	if len(profiles) == 0 {

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -65,9 +65,11 @@ You should have admin rights.
 Option is required:
 	name - Uniq name for new event. Should be one word with chars and digits only 
 
-/event list
-Show all event. It could be sent in group chat or in a direct chat with Valera.
-You should have admin rights.
+/event list \[-a | all]
+Show all active event. It could be sent in group chat or in a direct chat with Valera.
+Options:
+	-a (or "all") shows all events either open or finished
+	
 
 /event close \[name] \[result]
 Close event with \[name] and \[result] options. It could be sent in group chat or in a direct chat with Valera.
@@ -152,16 +154,23 @@ func GetEventResult(event model.Event) string {
 	return msg.String()
 }
 
-// GetEventShow returns message for `/event show` command
-func GetEventShow(events []model.Event) string {
+// GetEventList returns message for `/event list` command
+func GetEventList(events []model.Event, all bool) string {
 	var msg strings.Builder
 
 	if len(events) == 0 {
 		msg.WriteString("Event list is empty")
 	} else {
-		msg.WriteString("List of events:\n")
-		for _, e := range events {
-			msg.WriteString(fmt.Sprintf("`%v` %v\n", e.Name, e.Status))
+		if all {
+			msg.WriteString("List of all events:\n")
+			for _, e := range events {
+				msg.WriteString(fmt.Sprintf("`%v` %v\n", e.Name, e.Status))
+			}
+		} else {
+			msg.WriteString("Active events:\n")
+			for _, e := range events {
+				msg.WriteString(fmt.Sprintf("`%s`\n", e.Name))
+			}
 		}
 	}
 

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -2,12 +2,11 @@ package message
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/alexboor/lbx-telebot/internal"
 	"github.com/alexboor/lbx-telebot/internal/wikimedia"
 	"gopkg.in/telebot.v3"
+	"strconv"
+	"strings"
 
 	"github.com/alexboor/lbx-telebot/internal/model"
 )
@@ -69,6 +68,11 @@ Option is required:
 Show all active event. It could be sent in group chat or in a direct chat with Valera.
 Options:
 	_-a_ (or "_all_") shows all events either open or finished
+
+*/event* info _NAME_
+Show the event information and bets
+Option is required:
+	NAME - Uniq name for new event. Should be one word with chars and digits only 
 	
 */event* my _NAME_
 Show your personal bet in the particular event
@@ -181,6 +185,33 @@ func GetEventList(events []model.Event, all bool) string {
 				msg.WriteString(fmt.Sprintf("`%s`\n", e.Name))
 			}
 		}
+	}
+
+	return msg.String()
+}
+
+func GetEventInfo(e model.Event, bets []string, winners []model.Profile) string {
+	var msg strings.Builder
+
+	msg.WriteString(fmt.Sprintf("`%s`\n", e.Name))
+	msg.WriteString(fmt.Sprintf("Status: %s\n", e.Status))
+	msg.WriteString(fmt.Sprintf("Started: %s\n", e.CreatedAt.Format("02-01-2006 15:04")))
+
+	if e.Status == "finished" {
+		msg.WriteString(fmt.Sprintf("Finished: %s\n", e.FinishedAt.Format("02-01-2006 15:04")))
+	}
+
+	msg.WriteString(fmt.Sprintf("---\nBets: %v\n", strings.Join(bets, ", ")))
+
+	if e.Status == "finished" {
+		var ww []string
+		for _, v := range winners {
+			ww = append(ww, getName(v))
+		}
+
+		msg.WriteString("---\n")
+		msg.WriteString(fmt.Sprintf("Result: %d\n", e.Result))
+		msg.WriteString(fmt.Sprintf("Winner: %s\n", strings.Join(ww, ", ")))
 	}
 
 	return msg.String()

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -70,6 +70,15 @@ Show all active event. It could be sent in group chat or in a direct chat with V
 Options:
 	_-a_ (or "_all_") shows all events either open or finished
 	
+*/event* my _NAME_
+Show your personal bet in the particular event
+Option is required:
+	NAME - Uniq name for new event. Should be one word with chars and digits only 
+
+*/event* my _NAME_ rm
+Remove your personal bet from the particular event
+Option is required:
+	NAME - Uniq name for new event. Should be one word with chars and digits only 
 
 */event* close _NAME_ _RESULT_
 Close event with NAME and RESULT options. It could be sent in group chat or in a direct chat with Valera.

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -65,16 +65,16 @@ You should have admin rights.
 Option is required:
 	name - Uniq name for new event. Should be one word with chars and digits only 
 
+/event list
+Show all event. It could be sent in group chat or in a direct chat with Valera.
+You should have admin rights.
+
 /event close \[name] \[result]
 Close event with \[name] and \[result] options. It could be sent in group chat or in a direct chat with Valera.
 You should have admin rights.
 Options are required:
 	name - Uniq name for existing event. Should be one word with chars and digits only 
 	result - Result of the event. Should be number
-
-/event show
-Show all event. It could be sent in group chat or in a direct chat with Valera.
-You should have admin rights.
 
 /event result \[name]
 Show result for event with given name. It could be sent in group chat or in a direct chat with Valera.

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -17,37 +17,37 @@ func GetHelp() string {
 	return `
 *Available commands:*
 
-/help or /h
+*/help* or */h*
 Show this help.
 
-/ver or /v
+*/ver* or */v*
 Show the current version.
 
-/profile \[name] \[period]
+*/profile* _NAME_ _PERIOD_
 Show the stored profile of the requester or another user.
 Options:
-	name - target chat participant
-	period - custom period of statistic (e.g. 7d, 72h), should be > 0
+	_NAME_ - target chat participant
+	_PERIOD_ - custom period of statistic (e.g. 7d, 72h), should be > 0
 
-/top \[num] \[period]
+*/top* _NUM_ _PERIOD_
 Show top users.
 Options:
-	num - custom number of positions to show, should be > 0
-	period - custom period of statistic (e.g. 7d, 72h), should be > 0
+	_NUM_ - custom number of positions to show, should be > 0
+	_PERIOD_ - custom period of statistic (e.g. 7d, 72h), should be > 0
 
-/bottom \[num] \[period]
+*/bottom* _NUM_ _PERIOD_
 Show reversed rating
 Options:
-	num - custom number of positions to show, should be > 0
-	period - custom period of statistic (e.g. 7d, 72h), should be > 0
+	_NUM_ - custom number of positions to show, should be > 0
+	_PERIOD_ - custom period of statistic (e.g. 7d, 72h), should be > 0
 
-/topic text
+*/topic* _text_
 Set new title in the group
 
-/event
+*/event*
 Command for event. Send command without params for detailed instructions.
 
-/today
+*/today*
 Returns what happened on this day
 
 I live here: https://github.com/alexboor/lbx-telebot
@@ -59,40 +59,40 @@ func GetEventInstruction() string {
 	return `
 Available commands:
 
-/event create \[name]
-Create new event with \[name] option. It could be sent in group chat or in a direct chat with Valera.
+*/event* create _NAME_
+Create new event with _NAME_ option. It could be sent in group chat or in a direct chat with Valera.
 You should have admin rights.
 Option is required:
-	name - Uniq name for new event. Should be one word with chars and digits only 
+	NAME - Uniq name for new event. Should be one word with chars and digits only 
 
-/event list \[-a | all]
+*/event* list \[_-a_ | _all_]
 Show all active event. It could be sent in group chat or in a direct chat with Valera.
 Options:
-	-a (or "all") shows all events either open or finished
+	_-a_ (or "_all_") shows all events either open or finished
 	
 
-/event close \[name] \[result]
-Close event with \[name] and \[result] options. It could be sent in group chat or in a direct chat with Valera.
+*/event* close _NAME_ _RESULT_
+Close event with NAME and RESULT options. It could be sent in group chat or in a direct chat with Valera.
 You should have admin rights.
 Options are required:
-	name - Uniq name for existing event. Should be one word with chars and digits only 
-	result - Result of the event. Should be number
+	_NAME_ - Uniq name for existing event. Should be one word with chars and digits only 
+	_RESULT_ - Result of the event. Should be number
 
-/event result \[name]
+*/event* result _NAME_
 Show result for event with given name. It could be sent in group chat or in a direct chat with Valera.
 Option is required:
-	name - Uniq name for existing event. Should be one word with chars and digits only 
+	_NAME_ - Uniq name for existing event. Should be one word with chars and digits only 
 
-/event bet \[name] \[value]
+*/event* bet _NAME_ _VALUE_
 Make your bet with value. It could be sent in group chat or in a direct chat with Valera.
 Options are required:
-	name - Uniq name for existing event. Should be one word with chars and digits only 
-	value - Your bet for this event. Should be number
+	_NAME_ - Uniq name for existing event. Should be one word with chars and digits only 
+	_VALUE_ - Your bet for this event. Should be number
 
-/event share \[name]
+*/event* share _NAME_
 Share event in administered groups
 Option is required:
-	name - Uniq name for existing event. Should be one word with chars and digits only`
+	_NAME_ - Uniq name for existing event. Should be one word with chars and digits only`
 }
 
 // GetEventShareKeyboard returns message and keyboard for `/event share` cmd with groups

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -17,6 +17,7 @@ const (
 	EventBet
 	EventResult
 	EventShare
+	EventMy
 )
 
 type (
@@ -92,6 +93,12 @@ func GetNewEvent(author int64, payload string) (Event, bool) {
 		}
 		result = newEvent(EventBet, opts[1], author, opts)
 		result.Bet = bet
+
+	case "my":
+		if len(opts) < 2 || len(opts) > 3 {
+			return result, false
+		}
+		result = newEvent(EventMy, opts[1], author, opts)
 
 	default:
 		return result, false

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -18,6 +18,7 @@ const (
 	EventResult
 	EventShare
 	EventMy
+	EventInfo
 )
 
 type (
@@ -99,6 +100,12 @@ func GetNewEvent(author int64, payload string) (Event, bool) {
 			return result, false
 		}
 		result = newEvent(EventMy, opts[1], author, opts)
+
+	case "info":
+		if len(opts) != 2 {
+			return result, false
+		}
+		result = newEvent(EventInfo, opts[1], 0, opts)
 
 	default:
 		return result, false

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -13,7 +13,7 @@ const (
 
 	EventCreate = iota
 	EventClose
-	EventShow
+	EventList
 	EventBet
 	EventResult
 	EventShare
@@ -32,6 +32,7 @@ type (
 		FinishedAt     time.Time
 		WinnerIds      []int64
 		WinnerProfiles []Profile
+		Opts           []string
 	}
 )
 
@@ -48,7 +49,7 @@ func GetNewEvent(author int64, payload string) (Event, bool) {
 		if len(opts) != 2 {
 			return result, false
 		}
-		result = newEvent(EventCreate, opts[1], author)
+		result = newEvent(EventCreate, opts[1], author, opts)
 
 	case "close":
 		if len(opts) != 3 {
@@ -59,26 +60,26 @@ func GetNewEvent(author int64, payload string) (Event, bool) {
 		if err != nil {
 			return result, false
 		}
-		result = newEvent(EventClose, opts[1], author)
+		result = newEvent(EventClose, opts[1], author, opts)
 		result.Result = evRes
 
 	case "list":
-		if len(opts) != 1 {
+		if len(opts) > 2 {
 			return result, false
 		}
-		result = newEvent(EventShow, "", 0)
+		result = newEvent(EventList, "", 0, opts)
 
 	case "result":
 		if len(opts) != 2 {
 			return result, false
 		}
-		result = newEvent(EventResult, opts[1], 0)
+		result = newEvent(EventResult, opts[1], 0, opts)
 
 	case "share":
 		if len(opts) != 2 {
 			return result, false
 		}
-		result = newEvent(EventShare, opts[1], 0)
+		result = newEvent(EventShare, opts[1], 0, opts)
 
 	case "bet":
 		if len(opts) != 3 {
@@ -89,7 +90,7 @@ func GetNewEvent(author int64, payload string) (Event, bool) {
 		if err != nil {
 			return result, false
 		}
-		result = newEvent(EventBet, opts[1], author)
+		result = newEvent(EventBet, opts[1], author, opts)
 		result.Bet = bet
 
 	default:
@@ -123,13 +124,14 @@ func (e *Event) SetWinners(participants []Participant) {
 	}
 }
 
-func newEvent(cmd int, name string, author int64) Event {
+func newEvent(cmd int, name string, author int64, opts []string) Event {
 	return Event{
 		Cmd:       cmd,
 		Name:      name,
 		Status:    getStatus(cmd),
 		AuthorId:  author,
 		WinnerIds: []int64{},
+		Opts:      opts,
 	}
 }
 

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -62,7 +62,7 @@ func GetNewEvent(author int64, payload string) (Event, bool) {
 		result = newEvent(EventClose, opts[1], author)
 		result.Result = evRes
 
-	case "show":
+	case "list":
 		if len(opts) != 1 {
 			return result, false
 		}

--- a/internal/storage/postgres/event.go
+++ b/internal/storage/postgres/event.go
@@ -183,3 +183,10 @@ func (s *Storage) GetEventWithWinnersByName(ctx context.Context, name string) (m
 
 	return event, nil
 }
+
+// RemoveBet for the particular user from the given event
+func (s *Storage) RemoveBet(ctx context.Context, event model.Event, userId int64) error {
+	query := `DELETE FROM event_participant WHERE event_name = $1 AND user_id = $2`
+	_, err := s.Pool.Exec(ctx, query, event.Name, userId)
+	return err
+}

--- a/internal/storage/postgres/event.go
+++ b/internal/storage/postgres/event.go
@@ -97,10 +97,13 @@ where event_name = $1`
 }
 
 // GetAllEvents returns all events
-func (s *Storage) GetAllEvents(ctx context.Context) ([]model.Event, error) {
-	query := `
-select name, created_at, finished_at, author, result, status, winners
-from event`
+func (s *Storage) GetAllEvents(ctx context.Context, all bool) ([]model.Event, error) {
+	query := `select name, created_at, finished_at, author, result, status, winners
+					from event where status = 'opened'`
+	if all {
+		query = `select name, created_at, finished_at, author, result, status, winners
+					from event`
+	}
 
 	rows, err := s.Pool.Query(ctx, query)
 	if err != nil {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -22,6 +22,6 @@ type Storage interface {
 	CloseEvent(ctx context.Context, event model.Event) error
 	GetProfilesById(ctx context.Context, ids []int64) ([]model.Profile, error)
 	GetProfileById(ctx context.Context, id int64) (model.Profile, error)
-	GetAllEvents(ctx context.Context) ([]model.Event, error)
+	GetAllEvents(ctx context.Context, all bool) ([]model.Event, error)
 	StoreBet(ctx context.Context, event model.Event, userId int64) error
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -24,4 +24,5 @@ type Storage interface {
 	GetProfileById(ctx context.Context, id int64) (model.Profile, error)
 	GetAllEvents(ctx context.Context, all bool) ([]model.Event, error)
 	StoreBet(ctx context.Context, event model.Event, userId int64) error
+	RemoveBet(ctx context.Context, event model.Event, userId int64) error
 }


### PR DESCRIPTION
Refactoring /event show to /event list command. Now it shows only opened event by default. To get all event need use -a param.
Added  /event my %eventname% command to show personal bet for the event
Added /event my %eventname% rm command to remove personal ber from the event Close #26
Added /event info %eventname% to get event info and bets Close #25
Fix confirmation channel Fix #23 